### PR TITLE
Use camel case coding style for manual autoload

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,12 +1,6 @@
 <?php
 /**
- * An example of a project-specific implementation.
- *
- * After registering this autoload function with SPL, the following line
- * would cause the function to attempt to load the \Foo\Bar\Baz\Qux class
- * from /path/to/project/src/Baz/Qux.php:
- *
- *      new \Foo\Bar\Baz\Qux;
+ * This is an bingo-functional autoloader
  *
  * @param string $class The fully-qualified class name.
  *
@@ -18,7 +12,7 @@ spl_autoload_register(function ($class) {
     $prefix = 'Chemem\\Bingo\\Functional\\';
 
     // base directory for the namespace prefix
-    $base_dir = __DIR__.'/src/';
+    $baseDir = __DIR__.'/src/';
 
     // does the class use the namespace prefix?
     $len = strlen($prefix);
@@ -28,12 +22,12 @@ spl_autoload_register(function ($class) {
     }
 
     // get the relative class name
-    $relative_class = substr($class, $len);
+    $relativeClass = substr($class, $len);
 
     // replace the namespace prefix with the base directory, replace namespace
     // separators with directory separators in the relative class name, append
     // with .php
-    $file = $base_dir.str_replace('\\', '/', $relative_class).'.php';
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
 
     // if the file exists, require it
     if (file_exists($file)) {
@@ -47,7 +41,7 @@ spl_autoload_register(function ($class) {
     $prefix = 'Chemem\\Bingo\\Functional\\Tests\\';
 
     // base directory for the namespace prefix
-    $base_dir = __DIR__.'/tests/';
+    $baseDir = __DIR__.'/tests/';
 
     // does the class use the namespace prefix?
     $len = strlen($prefix);
@@ -57,12 +51,12 @@ spl_autoload_register(function ($class) {
     }
 
     // get the relative class name
-    $relative_class = substr($class, $len);
+    $relativeClass = substr($class, $len);
 
     // replace the namespace prefix with the base directory, replace namespace
     // separators with directory separators in the relative class name, append
     // with .php
-    $file = $base_dir.str_replace('\\', '/', $relative_class).'.php';
+    $file = $baseDir . str_replace('\\', '/', $relativeClass).'.php';
 
     // if the file exists, require it
     if (file_exists($file)) {


### PR DESCRIPTION
# Changed log
- According to the [comment](https://github.com/ace411/bingo-functional/commit/50a61d2d1fa704c7b2b79226c94f86f5bbd4fd81), let the `autoload` be the camel case coding style.
- Modify the description of `autoload`.