### PR TITLE
Modified IO functions

### DIFF
--- a/src/Functors/Monads/IO/simple.php
+++ b/src/Functors/Monads/IO/simple.php
@@ -63,8 +63,8 @@ const putChar = 'Chemem\\Bingo\\Functional\\Functors\\Monads\\IO\\putChar';
 
 function putChar(string $char): IOMonad
 {
-    $input = mb_strlen($char, 'utf-8') == 1 ? 
-        $char : 
+    $input = mb_strlen($char, 'utf-8') == 1 ?
+        $char :
         substr($char, 0, 1);
     
     return putStr($input);

--- a/src/Functors/Monads/IO/simple.php
+++ b/src/Functors/Monads/IO/simple.php
@@ -88,6 +88,23 @@ function putStr(string $str): IOMonad
 }
 
 /**
+ * putStrLn function
+ * Same as putStr but adds a newline character
+ *
+ * putStrLn :: String -> IO ()
+ *
+ * @return object IO
+ */
+const putStrLn = __NAMESPACE__ . '\\putStrLn';
+
+function putStrLn(string $str): IOMonad
+{
+    return IO(function () use ($str): int {
+        return fputs(STDIN, A\concat("\n", $str, ''));
+    });
+}
+
+/**
  * getLine function
  * Read a line from the standard input device.
  *

--- a/src/Functors/Monads/IO/simple.php
+++ b/src/Functors/Monads/IO/simple.php
@@ -43,10 +43,12 @@ const getChar = 'Chemem\\Bingo\\Functional\\Functors\\Monads\\IO\\getChar';
 
 function getChar(): IOMonad
 {
-    return putChar()
-        ->map(function (callable $fget) {
-            return A\toException($fget)(\STDIN);
-        });
+    return IO(function () {
+        $char = trim(fgetc(STDIN));
+        fclose(STDIN);
+
+        return $char;
+    });
 }
 
 /**
@@ -59,11 +61,13 @@ function getChar(): IOMonad
  */
 const putChar = 'Chemem\\Bingo\\Functional\\Functors\\Monads\\IO\\putChar';
 
-function putChar(): IOMonad
+function putChar(string $char): IOMonad
 {
-    return IO(function () {
-        return A\compose('fgetc', 'trim');
-    });
+    $input = mb_strlen($char, 'utf-8') == 1 ? 
+        $char : 
+        substr($char, 0, 1);
+    
+    return putStr($input);
 }
 
 /**
@@ -76,10 +80,10 @@ function putChar(): IOMonad
  */
 const putStr = 'Chemem\\Bingo\\Functional\\Functors\\Monads\\IO\\putStr';
 
-function putStr(): IOMonad
+function putStr(string $str): IOMonad
 {
-    return IO(function () {
-        return A\compose('fgets', 'trim');
+    return IO(function () use ($str): int {
+        return fputs(STDIN, $str);
     });
 }
 
@@ -95,12 +99,12 @@ const getLine = 'Chemem\\Bingo\\Functional\\Functors\\Monads\\IO\\getLine';
 
 function getLine(): IOMonad
 {
-    return putStr()
-        ->map(function (callable $fget) {
-            $result = A\toException($fget)(\STDIN);
+    return IO(function () {
+        $res = trim(fgets(STDIN));
+        fclose(STDIN);
 
-            return A\concat(\PHP_EOL, $result, A\identity(''));
-        });
+        return $res;
+    });
 }
 
 /**

--- a/tests/IOMonadTest.php
+++ b/tests/IOMonadTest.php
@@ -103,14 +103,16 @@ class IOMonadTest extends \PHPUnit\Framework\TestCase
 
     public function testPutCharFunctionOutputsFunctionWrappedInsideIO()
     {
-        $this->assertInstanceOf(IO::class, putChar());
-        $this->assertInstanceOf(\Closure::class, putChar()->exec());
+        $action = putChar('a');
+
+        $this->assertInstanceOf(IO::class, $action);
     }
 
     public function testPutStrFunctionOutputsFunctionWrappedInsideIO()
     {
-        $this->assertInstanceOf(IO::class, putStr());
-        $this->assertInstanceOf(\Closure::class, putStr()->exec());
+        $action = putStr('abc');
+        
+        $this->assertInstanceOf(IO::class, $action);
     }
 
     public function testReadIOMethodReadsStringInput()

--- a/tests/IOMonadTest.php
+++ b/tests/IOMonadTest.php
@@ -115,6 +115,13 @@ class IOMonadTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(IO::class, $action);
     }
 
+    public function testPutStrLnOutputsIOInstance()
+    {
+        $action = IO\putStrLn('test>');
+
+        $this->assertInstanceOf(IO::class, $action);
+    }
+
     public function testReadIOMethodReadsStringInput()
     {
         $read = readIO(IO('foo'));


### PR DESCRIPTION
I completely misread the type signatures of the functions `putStr`, `getLine`, `putChar`, and `getChar` - the result was incorrect definitions. The patch in this Pull Request is a proper adaptation of the Haskell-inspired functions. 

Per the new definitions, the following compositions are possible:

```php
$chrio = mcompose(IO\getChar, IO\putChar); //character IO

$strio = mcompose(IO\getLine, IO\putStr); //string IO
```

Also, I've added the `putStrLn` function which adds a newline character to every string input.