### PR TITLE
Made changes compatible with versions of PHP 7.4 and older

### DIFF
--- a/src/Algorithms/CountOf.php
+++ b/src/Algorithms/CountOf.php
@@ -20,7 +20,7 @@ function countOfValue(array $list, $value): int
     foreach ($list as $val) {
         $count += is_array($val) ?
             countOfValue($val, $value) :
-            $val == $value ? 1 : 0;
+            ($val == $value ? 1 : 0);
     }
 
     return $count;
@@ -44,7 +44,7 @@ function countOfKey(array $list, string $skey): int
     foreach ($list as $key => $val) {
         $count += is_array($val) ?
             countOfKey($val, $skey) :
-            $key == $skey ? 1 : 0;
+            ($key == $skey ? 1 : 0);
     }
 
     return $count;

--- a/src/Immutable/Collection.php
+++ b/src/Immutable/Collection.php
@@ -20,9 +20,10 @@ class Collection implements \JsonSerializable, \IteratorAggregate, \Countable, I
      */
     public function map(callable $func): ImmutableList
     {
-        $list = $this->getList();
-        for ($idx = 0; $idx < $list->count(); $idx++) {
-            $list[$idx] = $func($list[$idx]);
+        $count = $this->count();
+        $list = new \SplFixedArray($count);
+        for ($idx = 0; $idx < $count; $idx++) {
+            $list[$idx] = $func($this->getList()[$idx]);
         }
 
         return new static($list);

--- a/src/Immutable/Collection.php
+++ b/src/Immutable/Collection.php
@@ -9,11 +9,16 @@
 
 namespace Chemem\Bingo\Functional\Immutable;
 
-use \Chemem\Bingo\Functional\Algorithms as A;
+use \Chemem\Bingo\Functional\{
+    Algorithms as A,
+    Common\Traits\TransientMutator as Transient
+};
+
 
 class Collection implements \JsonSerializable, \IteratorAggregate, \Countable, ImmutableList
 {
     use CommonTrait;
+    use Transient;
 
     /**
      * {@inheritdoc}
@@ -91,7 +96,24 @@ class Collection implements \JsonSerializable, \IteratorAggregate, \Countable, I
             }
         }
 
-        return new static($old);
+        return $this->update($old);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mergeN(ImmutableList ...$lists): ImmutableList
+    {
+        return $this->merge(
+            array_shift($lists)
+                ->triggerMutation(function ($list) use ($lists) {
+                    for ($idx = 0; $idx < count($lists); $idx++) {
+                        $list->merge($lists[$idx]);
+                    }
+
+                    return $list; 
+                })
+        );
     }
 
     /**
@@ -309,5 +331,18 @@ class Collection implements \JsonSerializable, \IteratorAggregate, \Countable, I
     public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->toArray());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function update(\SplFixedArray $list)
+    {
+        if ($this->isMutable()) {
+            $this->list = $list;
+            return $this;
+        }
+
+        return new static($list);
     }
 }

--- a/src/Immutable/ImmutableList.php
+++ b/src/Immutable/ImmutableList.php
@@ -74,6 +74,17 @@ interface ImmutableList extends ImmutableDataStructure
     public function merge(ImmutableList $list): ImmutableList;
 
     /**
+     * mergeN method.
+     *
+     * @method merge
+     *
+     * @param ImmutableList... $list
+     *
+     * @return ImmutableList
+     */
+    public function mergeN(ImmutableList ...$lists): ImmutableList;
+    
+    /**
      * reverse method.
      *
      * @method reverse

--- a/src/PatternMatching/functions.php
+++ b/src/PatternMatching/functions.php
@@ -251,6 +251,10 @@ function evalStringPattern(array $patterns, string $value)
                             $valType == 'double' ? (float) $val : $val;
                     },
                     function ($val) use ($value) {
+                        if (empty($value)) {
+                            return '_';
+                        }
+                        
                         return $val == $value ? A\concat('"', '', $val, '') : '_';
                     }
                 );

--- a/src/PatternMatching/functions.php
+++ b/src/PatternMatching/functions.php
@@ -9,7 +9,10 @@
 
 namespace Chemem\Bingo\Functional\PatternMatching;
 
-use Chemem\Bingo\Functional\Algorithms as A;
+use Chemem\Bingo\Functional\{
+    Algorithms as A,
+    Functors\Maybe
+};
 
 /**
  * match function.
@@ -109,19 +112,30 @@ const patternMatch = 'Chemem\\Bingo\\Functional\\PatternMatching\\patternMatch';
 
 function patternMatch(array $patterns, $value)
 {
-    switch ($value) {
-        case is_object($value):
-            return evalObjectPattern($patterns, $value);
-            break;
+    $matches = Maybe\Maybe::just($value)
+        ->filter(function ($value) {
+            return !empty($value) || !isset($value);
+        });
 
-        case is_array($value):
-            return evalArrayPattern($patterns, $value);
-            break;
+    return Maybe\maybe(
+        key_exists('_', $patterns) ? ($patterns['_'])() : false, 
+        function ($value) use ($patterns) {
+            switch ($value) {
+                case is_object($value):
+                    return evalObjectPattern($patterns, $value);
+                    break;
 
-        default:
-            return evalStringPattern($patterns, $value);
-            break;
-    }
+                case is_array($value):
+                    return evalArrayPattern($patterns, $value);
+                    break;
+
+                case is_string($value):
+                    return evalStringPattern($patterns, $value);
+                    break;
+            }
+        }, 
+        $matches
+    );
 }
 
 /**

--- a/src/PatternMatching/functions.php
+++ b/src/PatternMatching/functions.php
@@ -262,7 +262,7 @@ function evalStringPattern(array $patterns, string $value)
 
                         return $valType == 'integer' ?
                             (int) $val :
-                            $valType == 'double' ? (float) $val : $val;
+                            ($valType == 'double' ? (float) $val : $val);
                     },
                     function ($val) use ($value) {
                         if (empty($value)) {

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -421,4 +421,36 @@ class CollectionTest extends TestCase
         $this->expectException(\OutOfRangeException::class);
         $list->offsetGet(7);
     }
+
+    public function mergeMultipleProvider()
+    {
+        return [
+            [
+                range(1, 5),
+                range(6, 10),
+                range(11, 15),
+                range(1, 15)
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider mergeMultipleProvider
+     */
+    public function testMergeNMethodFusesMultipleListsIntoOneAmalgam(
+        $fst, 
+        $snd, 
+        $thd, 
+        $res
+    )
+    {
+        $list = Collection::from($fst);
+        $merged = $list->mergeN(
+            Collection::from($snd),
+            Collection::from($thd)
+        );
+
+        $this->assertInstanceOf(Collection::class, $merged);
+        $this->assertEquals(Collection::from($res)->toArray(), $merged->toArray());
+    }
 }

--- a/tests/PatternMatchTest.php
+++ b/tests/PatternMatchTest.php
@@ -92,6 +92,7 @@ class PatternMatchTest extends TestCase
 
         $this->assertEquals($numbers(1), 'first');
         $this->assertEquals($numbers(24), 'undefined');
+        $this->assertEquals('undefined', $numbers(''));
     }
 
     public function testArrayPatternEvaluatesArrayPatterns()


### PR DESCRIPTION
- **Fixed deprecated code** Per the PHP 7.4 spec, [Nested ternary operators without explicit parentheses are no-longer outstandingly valid](https://www.php.net/manual/en/migration74.deprecated.php).

- **Added `mergeN` function** Extended - via Transient - the immutable Collection class to include the mergeN method.

- **Modified `patternMatch` function** Wrapped the previous switch statement in a Maybe monad evaluation sequence. 