### PR TITLE
Add Object Support to pluck and pick

### DIFF
--- a/src/Algorithms/CountOf.php
+++ b/src/Algorithms/CountOf.php
@@ -20,7 +20,7 @@ function countOfValue(array $list, $value): int
     foreach ($list as $val) {
         $count += is_array($val) ?
             countOfValue($val, $value) :
-            $val == $value ? 1 : 0;
+            ($val == $value ? 1 : 0);
     }
 
     return $count;
@@ -44,7 +44,7 @@ function countOfKey(array $list, string $skey): int
     foreach ($list as $key => $val) {
         $count += is_array($val) ?
             countOfKey($val, $skey) :
-            $key == $skey ? 1 : 0;
+            ($key == $skey ? 1 : 0);
     }
 
     return $count;

--- a/src/PatternMatching/functions.php
+++ b/src/PatternMatching/functions.php
@@ -251,6 +251,10 @@ function evalStringPattern(array $patterns, string $value)
                             $valType == 'double' ? (float) $val : $val;
                     },
                     function ($val) use ($value) {
+                        if (empty($value)) {
+                            return '_';
+                        }
+                        
                         return $val == $value ? A\concat('"', '', $val, '') : '_';
                     }
                 );

--- a/src/PatternMatching/functions.php
+++ b/src/PatternMatching/functions.php
@@ -9,7 +9,10 @@
 
 namespace Chemem\Bingo\Functional\PatternMatching;
 
-use Chemem\Bingo\Functional\Algorithms as A;
+use Chemem\Bingo\Functional\{
+    Algorithms as A,
+    Functors\Maybe
+};
 
 /**
  * match function.
@@ -109,19 +112,30 @@ const patternMatch = 'Chemem\\Bingo\\Functional\\PatternMatching\\patternMatch';
 
 function patternMatch(array $patterns, $value)
 {
-    switch ($value) {
-        case is_object($value):
-            return evalObjectPattern($patterns, $value);
-            break;
+    $matches = Maybe\Maybe::just($value)
+        ->filter(function ($value) {
+            return !empty($value) || !isset($value);
+        });
 
-        case is_array($value):
-            return evalArrayPattern($patterns, $value);
-            break;
+    return Maybe\maybe(
+        key_exists('_', $patterns) ? ($patterns['_'])() : false, 
+        function ($value) use ($patterns) {
+            switch ($value) {
+                case is_object($value):
+                    return evalObjectPattern($patterns, $value);
+                    break;
 
-        default:
-            return evalStringPattern($patterns, $value);
-            break;
-    }
+                case is_array($value):
+                    return evalArrayPattern($patterns, $value);
+                    break;
+
+                case is_string($value):
+                    return evalStringPattern($patterns, $value);
+                    break;
+            }
+        }, 
+        $matches
+    );
 }
 
 /**

--- a/src/PatternMatching/functions.php
+++ b/src/PatternMatching/functions.php
@@ -262,7 +262,7 @@ function evalStringPattern(array $patterns, string $value)
 
                         return $valType == 'integer' ?
                             (int) $val :
-                            $valType == 'double' ? (float) $val : $val;
+                            ($valType == 'double' ? (float) $val : $val);
                     },
                     function ($val) use ($value) {
                         if (empty($value)) {

--- a/tests/PatternMatchTest.php
+++ b/tests/PatternMatchTest.php
@@ -92,6 +92,7 @@ class PatternMatchTest extends TestCase
 
         $this->assertEquals($numbers(1), 'first');
         $this->assertEquals($numbers(24), 'undefined');
+        $this->assertEquals('undefined', $numbers(''));
     }
 
     public function testArrayPatternEvaluatesArrayPatterns()


### PR DESCRIPTION
PHP objects are inherently iterable. It is, with the support added at this point, possible to iterate over objects and arrays alike.

```php
$obj = new class() {
  public string $foo = 'bar';
  
  public int $bar = 22;
};

$pick = f\pick($obj, 'bar'); //returns 'bar'

$pluck = f\pluck($obj, 'bar'); //returns 22
```