### PR TITLE
Fixed ap method in Just monad

### DIFF
--- a/src/Functors/Maybe/Just.php
+++ b/src/Functors/Maybe/Just.php
@@ -80,9 +80,11 @@ class Just extends Maybe
     /**
      * {@inheritdoc}
      */
-    public function ap(M\Monadic $app): M\Monadic
+    public function ap(M\Monadic $just): M\Monadic
     {
-        return $app->map($this);
+        return $this->bind(function ($action) use ($just) {
+            return $just->map($action);
+        });
     }
 
     /**

--- a/tests/MaybeTypeTest.php
+++ b/tests/MaybeTypeTest.php
@@ -26,6 +26,14 @@ class MaybeTypeTest extends TestCase
         $this->assertInstanceOf(Just::class, $val);
     }
 
+    public function testApMethodIsAHomomorphism()
+    {
+        $apply = Maybe::fromValue('strtoupper')->ap(Maybe::fromValue('foo'));
+
+        $this->assertInstanceOf(Maybe::class, $apply);
+        $this->assertEquals('FOO', $apply->getJust());
+    }
+
     public function testBindMethodEnablesSequentialChainOfJustType()
     {
         $maybe = Maybe::fromValue(2)


### PR DESCRIPTION
Modified `ap` method behavior per [issue 22](https://github.com/ace411/bingo-functional/issues/22). The said method is a homomorphism and should not behave as an alias for the map method.