### PR TITLE
TernaryToNull and AddDefaultValueUndefinedVariable

### DIFF
--- a/src/Functional/Memoize.php
+++ b/src/Functional/Memoize.php
@@ -48,6 +48,6 @@ function memoize(callable $function, bool $apc = false): callable
       $cache[$key] = $function(...$args);
     }
 
-    return isset($cache[$key]) ? $cache[$key] : $function(...$args);
+    return $cache[$key] ?? $function(...$args);
   };
 }

--- a/src/Functional/PluckPath.php
+++ b/src/Functional/PluckPath.php
@@ -35,9 +35,9 @@ function pluckPath($path, $list, $default = null)
   return fold(
     function ($acc, $key) use ($default) {
       if (\is_object($acc)) {
-        $acc = isset($acc->{$key}) ? $acc->{$key} : null;
+        $acc = $acc->{$key} ?? null;
       } elseif (\is_array($acc) || \is_iterable($acc)) {
-        $acc = isset($acc[$key]) ? $acc[$key] : null;
+        $acc = $acc[$key] ?? null;
       }
 
       return \is_null($acc) ? $default : $acc;

--- a/src/Functors/Monads/Nothing.php
+++ b/src/Functors/Monads/Nothing.php
@@ -17,11 +17,10 @@ class Nothing extends Maybe
 {
   public const of = __CLASS__ . '::of';
 
-  private $nothing;
+  private $nothing = null;
 
   public function __construct()
   {
-    $this->nothing = null;
   }
 
   /**

--- a/tests/Functors/FunctorTest.php
+++ b/tests/Functors/FunctorTest.php
@@ -22,8 +22,9 @@ class FunctorTest extends \PHPUnit\Framework\TestCase
         Generator\constant('foo')
       )
       ->then(function ($list) {
-        $fx = 'strtoupper';
-        $fy = f\partialRight(f\partial(f\concat, '-'), 'bar');
+        $item = null;
+        $fx   = 'strtoupper';
+        $fy   = f\partialRight(f\partial(f\concat, '-'), 'bar');
 
         $this->assertEquals(
           [
@@ -45,8 +46,9 @@ class FunctorTest extends \PHPUnit\Framework\TestCase
         Generator\constant('foo')
       )
       ->then(function ($list) {
-        $fx = 'strtoupper';
-        $fy = f\partialRight(f\partial(f\concat, '-'), 'bar');
+        $item = null;
+        $fx   = 'strtoupper';
+        $fy   = f\partialRight(f\partial(f\concat, '-'), 'bar');
 
         $this->assertEquals(
           [


### PR DESCRIPTION
# Changed log

- Using the `??` syntax to improve the `TernaryToNull` issue.
- Defining the `null` to be the default value for these undefined variables.