### PR TITLE
v2.5.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <span style="display:block;text-align:center;" align="center">
 
 [![Join the chat at https://gitter.im/bingo-functional/Lobby](https://badges.gitter.im/bingo-functional/Lobby.svg)](https://gitter.im/bingo-functional/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![StyleCI](https://github.styleci.io/repos/102261728/shield?branch=master)](https://github.styleci.io/repos/102261728?branch=master)
 ![bingo-functional CI](https://github.com/ace411/bingo-functional/workflows/bingo-functional%20CI/badge.svg)
 [![codecov](https://codecov.io/gh/ace411/bingo-functional/branch/master/graph/badge.svg)](https://codecov.io/gh/ace411/bingo-functional)
 [![Latest Stable Version](https://poser.pugx.org/chemem/bingo-functional/v/stable)](https://packagist.org/packages/chemem/bingo-functional)
@@ -41,11 +40,11 @@ Endeavor to create an issue on GitHub when the need arises or send an email to l
 
 ## Functional Programming in PHP
 
-I published a book titled - Functional Programming in PHP - which is currently available on LeanPub. The bingo-functional library features extensively in the text as a tool whose potencies demonstrate usage of Functional Programming ideas in PHP. I advise that you purchase a copy for $9.99.
+I collaborated with Apress to release a new edition of Functional Programming in PHP, which you, a prospective reader, can find on the [Apress bookstore](https://tinyurl.com/54ajymku). Featured prominently throughout the book are artifacts in this library whose origins (where necessary) and use cases are explored. I recommend you consider getting yourself a copy so you can further acquaint yourself with the paradigm and set yourself on a path to writing performant, composable code.
 
 <p align="center">
-    <a href="https://leanpub.com/functionalprogramminginphp">
-        <img src="https://s3.amazonaws.com/titlepages.leanpub.com/functionalprogramminginphp/hero?1540289375" width="30%">
+    <a href="https://tinyurl.com/54ajymku">
+        <img src="https://media.springernature.com/w600/springer-static/cover/book/979-8-8688-2468-5.jpg" width="20%">
     </a>
 </p>
 

--- a/changes.md
+++ b/changes.md
@@ -4,6 +4,12 @@
 
 - Added the following function(s)
   - `Chemem\Bingo\Functional\listFromPaths`
+- Preempt deprecation notices that may arise from invoking the following functions
+  - `Chemem\Bingo\Functional\fromPairs`
+  - `Chemem\Bingo\Functional\head`
+  - `Chemem\Bingo\Functional\dropLeft`
+  - `Chemem\Bingo\Functional\dropRight`
+  - `Chemem\Bingo\Functional\last`
 - Added nullable type definitions to arguments in the following functions
   - `Chemem\Bingo\Functional\paths`
   - `Chemem\Bingo\Functional\toException`
@@ -31,6 +37,7 @@
 - Improved iteration patterns in functions subsumed in the following classes
   - `Chemem\Bingo\Functional\Immutable\Collection`
   - `Chemem\Bingo\Functional\Immutable\Tuple`
+- Account for removal of `Ds\Vector` in ext-ds v2.0.0 in artifacts namespaced under `Chemem\Bingo\Functional\Immutable\`
 
 ## v2.4.0
 

--- a/src/Functional/FromPairs.php
+++ b/src/Functional/FromPairs.php
@@ -29,6 +29,8 @@ function fromPairs($list)
 {
   return fold(
     function ($acc, $val, $key) {
+      $count = 0;
+
       if (\is_array($val) || \is_object($val)) {
         $list = [];
 

--- a/src/Functional/Head.php
+++ b/src/Functional/Head.php
@@ -10,6 +10,10 @@
 
 namespace Chemem\Bingo\Functional;
 
+require_once __DIR__ . '/Internal/_Props.php';
+
+use function Chemem\Bingo\Functional\Internal\_props;
+
 const head = __NAMESPACE__ . '\\head';
 
 /**
@@ -37,11 +41,16 @@ function head($list, $default = null)
     return $default;
   }
 
-  \reset($list);
+  $data = \is_object($list) ?
+    _props($list) :
+    $list;
 
-  $result = \current($list);
+  \reset($data);
 
-  return equals($result, false) ?
-    $default :
-    $result;
+  $result = \current($data);
+  $key    = \key($data);
+
+  return isset($key) ?
+    $result :
+    $default;
 }

--- a/src/Functional/Internal/_Drop.php
+++ b/src/Functional/Internal/_Drop.php
@@ -11,6 +11,7 @@
 namespace Chemem\Bingo\Functional\Internal;
 
 require_once __DIR__ . '/_Fold.php';
+require_once __DIR__ . '/_Props.php';
 require_once __DIR__ . '/_Size.php';
 
 const _drop = __NAMESPACE__ . '\\_drop';
@@ -43,26 +44,41 @@ function _drop($list, $count, $left = true)
         break;
       }
     }
-  } else {
-    \end($list);
 
-    while ($idx < $count) {
-      $key = \key($list);
-      if (\is_object($list)) {
-        unset($list->{$key});
-      } elseif (\is_array($list)) {
-        unset($list[$key]);
-      }
-
-      $prev = \prev($list);
-
-      if (!$prev) {
-        \end($list);
-      }
-
-      $idx++;
-    }
+    return $list;
   }
 
-  return $list;
+  $obj = \is_object($list);
+  $tmp = $obj ?
+    _props($list) :
+    $list;
+
+  \end($tmp);
+
+  while ($idx < $count) {
+    $key = \key($tmp);
+
+    unset($tmp[$key]);
+
+    $prev = \prev($tmp);
+
+    if (!$prev) {
+      \end($tmp);
+    }
+
+    $idx++;
+  }
+
+  return $obj ?
+    _fold(
+      function ($acc, $value, $key) {
+        $acc->{$key} = $value;
+
+        return $acc;
+      },
+      $tmp,
+      (new \ReflectionClass($list))
+        ->newInstanceWithoutConstructor()
+    ) :
+    $tmp;
 }

--- a/src/Functional/Last.php
+++ b/src/Functional/Last.php
@@ -10,6 +10,10 @@
 
 namespace Chemem\Bingo\Functional;
 
+require_once __DIR__ . '/Internal/_Props.php';
+
+use function Chemem\Bingo\Functional\Internal\_props;
+
 const last = __NAMESPACE__ . '\\last';
 
 /**
@@ -36,11 +40,16 @@ function last($list, $default = null)
     return $default;
   }
 
-  \end($list);
+  $data = \is_object($list) ?
+    _props($list) :
+    $list;
 
-  $result = \current($list);
+  \end($data);
 
-  return equals($result, false) ?
-    $default :
-    $result;
+  $result = \current($data);
+  $key    = \key($data);
+
+  return isset($key) ?
+    $result :
+    $default;
 }

--- a/src/Immutable/CommonTrait.php
+++ b/src/Immutable/CommonTrait.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 
 namespace Chemem\Bingo\Functional\Immutable;
 
-use Ds\Vector;
+use Ds\{
+  Seq,
+  Vector,
+};
 use Chemem\Bingo\Functional as f;
 
 trait CommonTrait
@@ -42,7 +45,11 @@ trait CommonTrait
     // add support for ext-ds
     return new static(
       \extension_loaded('ds') ?
-        new Vector($list) :
+        (
+          \class_exists(Vector::class) ?
+            new Vector($list) :
+            new Seq($list)
+        ) :
         \SplFixedArray::fromArray($list)
     );
   }


### PR DESCRIPTION
- Preempt deprecation notices that may arise from invoking the following functions
  - `Chemem\Bingo\Functional\fromPairs`
  - `Chemem\Bingo\Functional\head`
  - `Chemem\Bingo\Functional\dropLeft`
  - `Chemem\Bingo\Functional\dropRight`
  - `Chemem\Bingo\Functional\last`
- Account for removal of `Ds\Vector` in ext-ds v2.0.0 in artifacts namespaced under `Chemem\Bingo\Functional\Immutable\`